### PR TITLE
adjust how we start the service so we can launch the image with a shell

### DIFF
--- a/docker-openldap/Dockerfile
+++ b/docker-openldap/Dockerfile
@@ -9,6 +9,7 @@ RUN echo 'slapd/root_password password password' | debconf-set-selections && \
 
 ADD init.ldif /
 ADD users.ldif /
+ADD start-ldap.sh /
 
 RUN service slapd start \
     && mkdir -p /var/ldap/example \
@@ -19,4 +20,4 @@ RUN service slapd start \
 
 EXPOSE 389
 
-CMD slapd -h 'ldap:///' -g openldap -u openldap -d 0
+ENTRYPOINT ["/start-ldap.sh"]

--- a/docker-openldap/start-ldap.sh
+++ b/docker-openldap/start-ldap.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+
+trap "echo TRAPed signal" HUP INT QUIT KILL TERM
+
+slapd -h 'ldap:///' -g openldap -u openldap -d 0 &
+
+exec "$@"


### PR DESCRIPTION
This changes the openldap image so you can launch it via 

`docker run -ti <imagename> /bin/bash` and get yourself an interactive shell (if you so desire)
