### PR TITLE
Remove lock file on boot, to prevent slapd refusing to start up again

### DIFF
--- a/389-ds/Dockerfile
+++ b/389-ds/Dockerfile
@@ -26,4 +26,7 @@ RUN useradd ldapadmin \
 
 EXPOSE 389
 
-CMD /usr/sbin/ns-slapd -D /etc/dirsrv/slapd-dir && tail -F /var/log/dirsrv/slapd-dir/access
+#  rm -fv is to fix unclean shutdown which prevents slapd starting up
+CMD rm -fv /var/lock/dirsrv/slapd-dir/server/* \
+    && /usr/sbin/ns-slapd -D /etc/dirsrv/slapd-dir \
+    && tail -F /var/log/dirsrv/slapd-dir/{access,errors}


### PR DESCRIPTION
Shutting down and starting up this container was a bit haphazard since the PID file hung around sometimes.